### PR TITLE
fix(cicd): SECURITY - https://about.codecov.io/security-update; DISABLED

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,6 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Build
         run: npx projen build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          directory: coverage
       - name: Commit and push changes (if any)
         run: 'git diff --exit-code || (git commit -am "chore: self mutation" && git push
           origin HEAD:${{ github.event.pull_request.head.ref }})'

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -15,7 +15,6 @@ const project = new AwsCdkTypeScriptApp({
 
   // docgen: true,
   gitpod: true,
-  codeCov: true,
 
   cdkDependencies: [
     '@aws-cdk/aws-dynamodb',


### PR DESCRIPTION
No CVE allocated

htps://docs.codecov.io/docs/about-the-codecov-bash-uploader
  `bash <$(curl foo)` strikes again with a fingerprint or checksum check
